### PR TITLE
feat: support multiple v8 profile files

### DIFF
--- a/python/nflxprofile/cli.py
+++ b/python/nflxprofile/cli.py
@@ -5,20 +5,25 @@ from nflxprofile.convert.v8_cpuprofile import parse as v8_parse
 
 def main():
     parser = argparse.ArgumentParser(prog="nflxprofile", description='Parse common profile/tracing formats into nflxprofile')
-    parser.add_argument('input')
     parser.add_argument('--output')
     parser.add_argument('--force', action="store_true")
+    parser.add_argument('--extra-options', type=json.loads)
+    parser.add_argument('input', nargs="+")
 
     args = parser.parse_args()
 
-    original = args.input
+    filenames = args.input
+    extra_options = args.extra_options or {}
     out = args.output
     if not out:
-        out = original.rsplit('.', 1)[0] + '.nflxprofile'
+        out = 'profile.nflxprofile'
 
     profile = None
-    with open(original, 'r') as f:
-        profile = v8_parse(json.loads(f.read()))
+    profiles = []
+    for filename in filenames:
+        with open(filename, 'r') as f:
+            profiles.append(json.loads(f.read()))
+    profile = v8_parse(profiles, **extra_options)
 
     with open(out, 'wb') as f:
         f.write(profile.SerializeToString())

--- a/python/nflxprofile/convert/v8_cpuprofile.py
+++ b/python/nflxprofile/convert/v8_cpuprofile.py
@@ -3,9 +3,11 @@ __ALL__ = ['parse']
 from nflxprofile import nflxprofile_pb2
 
 
-def get_cpuprofiles(chrome_profile):
-    if "nodes" in chrome_profile:
-        return [chrome_profile]
+def get_cpuprofiles(v8_profile):
+    if type(v8_profile) == list:
+        return v8_profile
+    if "nodes" in v8_profile:
+        return [v8_profile]
     raise TypeError("Unsupported V8 CPU Profile format")
 
 
@@ -43,8 +45,10 @@ def _generate_regular_stacks(nflxprofile_nodes, root_node_id):
             if  filename.startswith('file://'):
                 filename = filename[7:]
             stack_frame.file.file_name = filename
-            stack_frame.file.line = line
-            stack_frame.file.column = column
+            if line >= 0:
+                stack_frame.file.line = line
+            if column >= 0:
+                stack_frame.file.column = column
 
         stack_frame.function_name = function_name
         stack_frame.libtype = libtype
@@ -66,41 +70,99 @@ def get_idle_ids(nodes):
             idle_ids.append(node['id'])
     return idle_ids
 
-def parse(profile):
-    profile = get_cpuprofiles(profile)
-    # TODO (mmarchini): support multiple profiles
-    nodes = profile[0]
+
+def get_comm(v8_profile, index, **extra_options):
+    comms = extra_options.get('comms', [])
+    if len(comms) <= index:
+        return "(root)"
+    return comms[index]
+
+def get_pid(v8_profile, index, **extra_options):
+    pids = extra_options.get('pids', [])
+    if len(pids) <= index:
+        return index + 1
+    return pids[index]
+
+
+
+def parse(data, **extra_options):
+    """
+    """
+    v8_profiles = get_cpuprofiles(data)
 
     profile = nflxprofile_pb2.Profile()
     profile.nodes[0].function_name = 'root'
     profile.nodes[0].hit_count = 0
-    profile.nodes[0].children.append(1)
     profile.params['has_node_stack'] = 'true'
+    profile.params['has_node_pid'] = 'true'
+    profile.params['has_samples_pid'] = 'true'
 
-    profile.start_time = nodes['startTime']
-    profile.end_time = nodes['endTime']
-    profile.end_time = nodes['endTime']
+    root_ids = []
+    base_ids = []
 
-    stacks = _generate_regular_stacks(nodes['nodes'], 1)
+    profile.start_time = profile.end_time = 0
+    next_base_id = 0
+    for v8_profile in v8_profiles:
+        if profile.start_time == 0:
+            profile.start_time = v8_profile['startTime']
+        if profile.end_time == 0:
+            profile.end_time = v8_profile['endTime']
+        profile.start_time = min(profile.start_time, v8_profile['startTime'])
+        profile.end_time = max(profile.end_time, v8_profile['endTime'])
+        base_ids.append(next_base_id)
+        highest_id = 0
+        for index, node in enumerate(v8_profile['nodes']):
+            highest_id = max(node['id'], highest_id)
+        next_base_id += highest_id + 1
 
-    idle_ids = get_idle_ids(nodes['nodes'])
+    samples = []
 
-    node_id_cache = []
+    for v8_profile_idx, v8_profile in enumerate(v8_profiles):
+        comm = get_comm(v8_profile, v8_profile_idx, **extra_options)
+        pid = get_pid(v8_profile, v8_profile_idx, **extra_options)
+        base_id = base_ids[v8_profile_idx]
 
-    profile.time_deltas.append(0)
-    for index, node_id in enumerate(nodes['samples']):
-        if node_id in idle_ids:
-            continue
+        # TODO(mmarchini): detect root instead of assuming it is 1
+        root_ids.append(base_id + 1)
+        stacks = _generate_regular_stacks(v8_profile['nodes'], 1)
 
-        if node_id not in node_id_cache:
-            stack = stacks[node_id]
-            profile.nodes[node_id].function_name = '(root)'
-            profile.nodes[node_id].hit_count = 0
-            profile.nodes[node_id].stack.extend(stack)
-            node_id_cache.append(node_id)
+        idle_ids = get_idle_ids(v8_profile['nodes'])
 
+        node_id_cache = []
+
+        last_timestamp = v8_profile['startTime']
+        for index, node_id in enumerate(v8_profile['samples']):
+            if node_id in idle_ids:
+                continue
+
+
+            stack = None
+            if node_id not in node_id_cache:
+                stack = stacks[node_id]
+                node_id_cache.append(node_id)
+
+            node_id = base_id + node_id
+
+            if stack:
+                profile.nodes[node_id].function_name = comm
+                profile.nodes[node_id].pid = pid
+                profile.nodes[node_id].hit_count = 0
+                profile.nodes[node_id].stack.extend(stack)
+
+            last_timestamp += v8_profile['timeDeltas'][index]
+
+            samples.append((last_timestamp, node_id, pid))
+            profile.nodes[node_id].hit_count += 1
+
+    samples = sorted(samples, key=lambda e: e[0])
+    last_timestamp = profile.start_time
+    profile.start_time = profile.start_time / 1000000.
+    profile.end_time = profile.end_time / 1000000.
+    for timestamp, node_id, pid in samples:
         profile.samples.append(node_id)
-        profile.time_deltas.append(nodes['timeDeltas'][index])
-        profile.nodes[node_id].hit_count += 1
+        profile.samples_pid.append(pid)
+        delta = (timestamp - last_timestamp) / 1000000.
+        profile.time_deltas.append(delta)
+        last_timestamp = timestamp
 
     return profile


### PR DESCRIPTION
In some cases users might capture profiles from multiple processes
simultaneously, and they might want to see those profiles in the same
Flame Graph (similar to how Linux perf works). This commit adds support
to parse multiple V8 CPU Profiles into a single nflxprofile. Each V8 CPU
Profile is identified through PID, which will either be a sequential
number or a given PID through the extra options parameter on the parse
function. Users now can also give a process name (comm) for each
profile.