### PR TITLE
fix: don't check for Node.js process name

### DIFF
--- a/python/nflxprofile/flamegraph.py
+++ b/python/nflxprofile/flamegraph.py
@@ -247,9 +247,6 @@ class NodeJsPackageStackProcessor(StackProcessor):
         return package
 
     def process(self, stack):
-        if stack[0].function_name != "node":
-            return
-
         # We always start with native
         current_frame = nflxprofile_pb2.StackFrame()
         current_frame.function_name = "(native)"


### PR DESCRIPTION
Don't check for `node` in the process name, as there's no
guarantee the process will be called that. This will cause everything
which is not a Node.js process to be flagged as `(native)` and `(kernel)`