### PR TITLE
feat: middle out merge

### DIFF
--- a/python/nflxprofile/flamegraph.py
+++ b/python/nflxprofile/flamegraph.py
@@ -202,7 +202,11 @@ class StackProcessor:
 
             if self.middle_out and middle_out_filter:
                 # middle out merge and no stack match yet
-                next_frame = stack[i + 1]
+                try:
+                    next_frame = stack[i + 1]
+                except IndexError:
+                    # this is the last frame
+                    continue
                 # checking next frame name for a match
                 if self.middle_out in next_frame.function_name:
                     # match on the next frame


### PR DESCRIPTION
Looking to implement middle-out merge, according to [this blog post](https://netflixtechblog.com/saving-13-million-computational-minutes-per-day-with-flame-graphs-d95633b6d01f). In a nutshell, it should filter out all stack frames until a string match is found (I'll likely change this to a regex before merging) in the "child" frame, basically ignoring all frames until the parent of a match. If there's no match in the whole stack, value goes to root.
Not the cleanest solution, but simplest for now. Let me know if you have a better idea.