### PR TITLE
Pin setuptools==59.6.0 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-dist: xenial
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
+language: python
+dist: xenial
+
 matrix:
   include:
     - name: Python
-      language: python
-      python:
-        - '3.7'
+      python: 3.7
 
-      before_script: cd python/ && pip3 install tox
+      before_install: cd python/
+      install:
+        # Pin setuptools to prevent build failures. See https://github.com/pypa/setuptools/issues/3118
+        - pip install setuptools==59.6.0
+        - pip install tox
 
-      script: python3 -m tox
+      script: python -m tox
 
       deploy:
         skip_cleanup: true


### PR DESCRIPTION
It looks like the recent CI failure is a specific issue with recent setuptools versions. [Thread](https://github.com/pypa/setuptools/issues/3118)

Let's see if pinning setuptools will fix [fix the build failure](https://app.travis-ci.com/github/Netflix/nflxprofile/jobs/590151098). 

```
$ cd python/ && pip3 install tox
0.37s$ python3 -m tox
GLOB sdist-make: /home/travis/build/Netflix/nflxprofile/python/setup.py
ERROR: invocation failed (exit code 1), logfile: /home/travis/build/Netflix/nflxprofile/python/.tox/log/GLOB-0.log
================================== log start ===================================
/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/setuptools/_importlib.py:23: UserWarning: `importlib-metadata` version is incompatible with `setuptools`
```